### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language: php
 env:
   - COMPOSER_DISABLE_XDEBUG_WARN=1
 
+branches:
+  only:
+    - master
+
 php:
   - 5.4
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ language: php
 env:
   - COMPOSER_DISABLE_XDEBUG_WARN=1
 
-branches:
-  only:
-    - master
-
 php:
   - 5.4
   - 5.5
@@ -55,7 +51,6 @@ matrix:
     - php: nightly
 
 before_script:
-  - composer self-update
   - COMPOSER=composer-travis-ci-coverage-${GET_COVERAGE}.json travis_retry composer install --no-interaction
 
 script:

--- a/composer-travis-ci-coverage-no.json
+++ b/composer-travis-ci-coverage-no.json
@@ -5,8 +5,10 @@
         }
     },
     "require": {
-        "php": ">=5.3",
-        "phpunit/phpunit": "4.6.10",
-        "phpunit/dbunit": "1.4.*"
+        "php": ">=5.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
+        "phpunit/dbunit": "^1.4"
     }
 }

--- a/composer-travis-ci-coverage-yes.json
+++ b/composer-travis-ci-coverage-yes.json
@@ -5,9 +5,11 @@
         }
     },
     "require": {
-        "php": ">=5.3",
-        "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "4.6.10",
-        "phpunit/dbunit": "1.4.*"
+        "php": ">=5.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
+        "phpunit/dbunit": "^1.4",
+        "satooshi/php-coveralls": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
     },
     "require": {
         "php": ">=5.3.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
     }
 }

--- a/test/tests/Addresses/AddressTypeTest.php
+++ b/test/tests/Addresses/AddressTypeTest.php
@@ -4,9 +4,9 @@ namespace IPLib\Test\Addresses;
 
 use IPLib\Factory;
 use IPLib\Address\Type;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AddressTypeTest extends PHPUnit_Framework_TestCase
+class AddressTypeTest extends TestCase
 {
     public function ipProvider()
     {

--- a/test/tests/Addresses/ConversionTest.php
+++ b/test/tests/Addresses/ConversionTest.php
@@ -3,8 +3,9 @@
 namespace IPLib\Test\Addresses;
 
 use IPLib\Factory;
+use PHPUnit\Framework\TestCase;
 
-class ConversionTest extends \PHPUnit_Framework_TestCase
+class ConversionTest extends TestCase
 {
     public function validAddressesProvider()
     {

--- a/test/tests/Addresses/IPv4MappedIPv6Test.php
+++ b/test/tests/Addresses/IPv4MappedIPv6Test.php
@@ -2,10 +2,10 @@
 
 namespace IPLib\Test\Addresses;
 
-use PHPUnit_Framework_TestCase;
 use IPLib\Factory;
+use PHPUnit\Framework\TestCase;
 
-class IPv4MappedIPv6Test extends PHPUnit_Framework_TestCase
+class IPv4MappedIPv6Test extends TestCase
 {
     public function mappedAddressProvider()
     {

--- a/test/tests/Addresses/InvalidTest.php
+++ b/test/tests/Addresses/InvalidTest.php
@@ -4,8 +4,9 @@ namespace IPLib\Test\Addresses;
 
 use IPLib\Address\IPv4;
 use IPLib\Address\IPv6;
+use PHPUnit\Framework\TestCase;
 
-class InvalidTest extends \PHPUnit_Framework_TestCase
+class InvalidTest extends TestCase
 {
     public function invalidAddressesProvider()
     {

--- a/test/tests/Addresses/PortsTest.php
+++ b/test/tests/Addresses/PortsTest.php
@@ -3,9 +3,9 @@
 namespace IPLib\Test\Addresses;
 
 use IPLib\Factory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PortsTest extends PHPUnit_Framework_TestCase
+class PortsTest extends TestCase
 {
     public function validAddresses()
     {

--- a/test/tests/Addresses/PreviousNextTest.php
+++ b/test/tests/Addresses/PreviousNextTest.php
@@ -3,8 +3,9 @@
 namespace IPLib\Test\Addresses;
 
 use IPLib\Factory;
+use PHPUnit\Framework\TestCase;
 
-class PreviousNextTest extends \PHPUnit_Framework_TestCase
+class PreviousNextTest extends TestCase
 {
     public function previousNextProvider()
     {

--- a/test/tests/Addresses/RangeTypeTest.php
+++ b/test/tests/Addresses/RangeTypeTest.php
@@ -4,9 +4,9 @@ namespace IPLib\Test\Addresses;
 
 use IPLib\Factory;
 use IPLib\Range\Type;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RangeTypeTest extends PHPUnit_Framework_TestCase
+class RangeTypeTest extends TestCase
 {
     public function ipProvider()
     {

--- a/test/tests/Addresses/ValidTest.php
+++ b/test/tests/Addresses/ValidTest.php
@@ -3,8 +3,9 @@
 namespace IPLib\Test\Addresses;
 
 use IPLib\Factory;
+use PHPUnit\Framework\TestCase;
 
-class ValidTest extends \PHPUnit_Framework_TestCase
+class ValidTest extends TestCase
 {
     public function validAddressesProvider()
     {

--- a/test/tests/Addresses/ZoneIdTest.php
+++ b/test/tests/Addresses/ZoneIdTest.php
@@ -3,9 +3,9 @@
 namespace IPLib\Test\Addresses;
 
 use IPLib\Factory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ZoneIdTest extends PHPUnit_Framework_TestCase
+class ZoneIdTest extends TestCase
 {
     public function validAddresses()
     {

--- a/test/tests/Ranges/BoundariesTest.php
+++ b/test/tests/Ranges/BoundariesTest.php
@@ -3,8 +3,9 @@
 namespace IPLib\Test\Ranges;
 
 use IPLib\Factory;
+use PHPUnit\Framework\TestCase;
 
-class BoundariesTest extends \PHPUnit_Framework_TestCase
+class BoundariesTest extends TestCase
 {
     public function boundariesProvider()
     {

--- a/test/tests/Ranges/FromBoundariesTest.php
+++ b/test/tests/Ranges/FromBoundariesTest.php
@@ -3,9 +3,9 @@
 namespace IPLib\Test\Ranges;
 
 use IPLib\Factory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class FromBoundariesTest extends PHPUnit_Framework_TestCase
+class FromBoundariesTest extends TestCase
 {
     public function invalidProvider()
     {

--- a/test/tests/Ranges/PatternTest.php
+++ b/test/tests/Ranges/PatternTest.php
@@ -4,8 +4,9 @@ namespace IPLib\Test\Ranges;
 
 use IPLib\Factory;
 use IPLib\Range\Pattern;
+use PHPUnit\Framework\TestCase;
 
-class PatternTest extends \PHPUnit_Framework_TestCase
+class PatternTest extends TestCase
 {
     public function invalidProvider()
     {

--- a/test/tests/Ranges/RangeTypeTest.php
+++ b/test/tests/Ranges/RangeTypeTest.php
@@ -4,9 +4,9 @@ namespace IPLib\Test\Ranges;
 
 use IPLib\Factory;
 use IPLib\Range\Type;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RangeTypeTest extends PHPUnit_Framework_TestCase
+class RangeTypeTest extends TestCase
 {
     public function ipProvider()
     {

--- a/test/tests/Ranges/SingleTest.php
+++ b/test/tests/Ranges/SingleTest.php
@@ -4,8 +4,9 @@ namespace IPLib\Test\Ranges;
 
 use IPLib\Factory;
 use IPLib\Range\Single;
+use PHPUnit\Framework\TestCase;
 
-class SingleTest extends \PHPUnit_Framework_TestCase
+class SingleTest extends TestCase
 {
     public function invalidProvider()
     {

--- a/test/tests/Ranges/SubnetTest.php
+++ b/test/tests/Ranges/SubnetTest.php
@@ -4,8 +4,9 @@ namespace IPLib\Test\Ranges;
 
 use IPLib\Factory;
 use IPLib\Range\Subnet;
+use PHPUnit\Framework\TestCase;
 
-class SubnetTest extends \PHPUnit_Framework_TestCase
+class SubnetTest extends TestCase
 {
     public function invalidProvider()
     {


### PR DESCRIPTION
# Changed log
- Using class-based PHPUnit namespace to be compatible with latest PHPUnit version.
- Set the multiple PHPUnit versions inside `require-dev` block in `composer.json` to support different PHP versions.
- Remove `branches` setting to let all branches execute Travis CI build.