### PR TITLE
Add ext-json in composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /.php_cs
 /.php_cs.cache
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,12 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+            "ext-pdo": "*",
+            "ext-pdo_sqlite": "*",
+            "phpunit/dbunit": "^1.4 || ^2 || ^3 || ^4",
+            "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
+        },
     "autoload": {
         "psr-4": {
             "IPLib\\": "src/"
@@ -36,11 +42,6 @@
         "psr-4": {
             "IPLib\\Test\\": "test/tests/"
         }
-    },
-    "require-dev": {
-        "ext-pdo_sqlite": "*",
-        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
-        "phpunit/dbunit": "^1.4 || ^2 || ^3 || ^4"
     },
     "scripts": {
         "test": "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,12 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-            "ext-pdo": "*",
-            "ext-pdo_sqlite": "*",
-            "phpunit/dbunit": "^1.4 || ^2 || ^3 || ^4",
-            "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
-        },
+        "ext-json": "*",
+        "ext-pdo": "*",
+        "ext-pdo_sqlite": "*",
+        "phpunit/dbunit": "^1.4 || ^2 || ^3 || ^4",
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
+    },
     "autoload": {
         "psr-4": {
             "IPLib\\": "src/"

--- a/test/tests/DBTestCase.php
+++ b/test/tests/DBTestCase.php
@@ -3,6 +3,7 @@
 namespace IPLib\Test;
 
 use PDO;
+use PHPUnit\DbUnit\Database\Connection;
 use PHPUnit\DbUnit\TestCase as PHPUnitTestCase;
 
 abstract class DBTestCase extends PHPUnitTestCase
@@ -13,7 +14,7 @@ abstract class DBTestCase extends PHPUnitTestCase
     private static $pdo = null;
 
     /**
-     * @var \PHPUnit\DbUnit\Database\Connection|null
+     * @var Connection|null
      */
     private $connection;
 


### PR DESCRIPTION
I've just noticed that also the `ext-json` extentions is referenced but not explicitly added to the `require-dev` section.