### PR TITLE
Php 8.4 deprecations fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         include:
           - os: windows-latest
             php-version: "5.5"


### PR DESCRIPTION
This PR solves a deprecation warning reported when using this library in PHP 8.4

The reason for this warning is a protected method from the `Factory` class which has two arguments implicitly marked as nullable by having a `null` default value.

https://github.com/mlocati/ip-lib/blob/125ab847272e53cfbc248948bd12e4c90ef96c68/src/Factory.php#L225

That is [deprecated in PHP 8.4](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types), and will error in PHP 9.0 and above.

One possible approach to solve that is explicitly marking the arguments as nullable (eg. `?AddressInterface $from = null` instead of `AddressInterface $from = null`), but that requires PHP 7.1, and this library supports older versions.

Since the method where this error is reported was `protected` and being called only from one place, I moved the logic there instead, removing the method entirely.

This can be a breaking change though, if anyone was extending from `Factory` and invoking this method from their own class, so perhaps this requires a major version bump.

Additionally, this PR also adds PHP 8.3 and 8.4 to the tests workflow matrix.

> Closes https://github.com/mlocati/ip-lib/issues/89